### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ACRObservingPlayerItem is a simple wrapper class for AVPlayerItem which handles 
 
 #### How?
 
-Install with Cocoapods
+Install with CocoaPods
 
 ```ruby
 pod "ACRObservingPlayerItem"
@@ -66,7 +66,7 @@ The entire point of the object is to automatically release the KVO when dealloca
 
 ##### Swift
 
-Version 1.1 was changed to support Swift through an Obj-C Bridging-Header file. Read this excellent tutorial to get started with Swift and Cocoapods: [Cocoapods with Swift](https://medium.com/@jigarm/cocoapods-with-swift-93bd373a7111)
+Version 1.1 was changed to support Swift through an Obj-C Bridging-Header file. Read this excellent tutorial to get started with Swift and CocoaPods: [CocoaPods with Swift](https://medium.com/@jigarm/cocoapods-with-swift-93bd373a7111)
 
 In your bridging header put:
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
